### PR TITLE
resolve #4 rubocop-railsを最新状態に更新

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -5,5 +5,5 @@ source "https://rubygems.org"
 git_source(:github) { |repo_name| "https://github.com/#{repo_name}" }
 
 gem "rubocop", "~> 0.54"
-gem "rubocop-rails", "~> 1.3"
-gem "byebug", "~> 10.0", :groups => [:development, :test]
+gem "rubocop-rails", "~> 1.4"
+gem "byebug", "~> 10.0", groups: [:development, :test]

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -78,7 +78,7 @@ PLATFORMS
 DEPENDENCIES
   byebug (~> 10.0)
   rubocop (~> 0.54)
-  rubocop-rails (~> 1.3)
+  rubocop-rails (~> 1.4)
 
 BUNDLED WITH
    1.16.1


### PR DESCRIPTION
https://github.com/keitakn/ruby-book-codes/issues/4

最新状態に更新した事で以下の警告は出なくなった。

```
vendor/bundle/ruby/2.5.0/gems/rubocop-rails-1.2.2/config/rails.yml: Lint/EndAlignment has the wrong namespace - should be Layout
```